### PR TITLE
deps: Don't include pybind if ZSWAG_BUILD_WHEELS is not set.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ if (ZSWAG_KEYCHAIN_SUPPORT)
   endif()
 endif()
 
-if (NOT TARGET pybind11)
+if (ZSWAG_BUILD_WHEELS AND NOT TARGET pybind11)
   add_subdirectory(deps/pybind11)
 endif()
 


### PR DESCRIPTION
### Changes
It's seems that the pybind dependency is only needed when zswag is instructed to build wheels - therefore I have included the option in the condition for including pybind.