### PR TITLE
Release: 1.4.0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -50,7 +50,7 @@ BreakBeforeTernaryOperators: false
 IndentAccessModifiers: false
 AccessModifierOffset: -4
 
-PenaltyIndentedWhitespace: 10
+PenaltyIndentedWhitespace: 100
 PenaltyBreakAssignment: 100
 PenaltyReturnTypeOnItsOwnLine: 100
 PenaltyBreakBeforeFirstCallParameter: 0

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,57 @@
+# Documentation:
+# https://releases.llvm.org/14.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+# CLion setup guide:
+# https://www.jetbrains.com/help/clion/clangformat-as-alternative-formatter.html#clion-support
+---
+BasedOnStyle: Chromium
+IndentWidth: 4
+---
+Language: Cpp
+ColumnLimit: 100
+
+# Always break after an open bracket, if the parameters don’t fit on a single line.
+AlignAfterOpenBracket: AlwaysBreak
+
+# Function call’s arguments will either be all on the same line or will have one line each.
+BinPackArguments: false
+BinPackParameters: false
+AllowAllArgumentsOnNextLine: false
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: MultiLine
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  BeforeLambdaBody: true
+
+# while (true) { continue; }
+AllowShortBlocksOnASingleLine: Always
+AllowShortLambdasOnASingleLine: Empty
+
+# case 1: return 2;
+AllowShortCaseLabelsOnASingleLine: true
+IndentCaseBlocks: false
+IndentCaseLabels: false
+
+AlignOperands: false
+ContinuationIndentWidth: 4
+
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: false
+
+IndentAccessModifiers: false
+AccessModifierOffset: -4
+
+PenaltyIndentedWhitespace: 10
+PenaltyBreakAssignment: 100
+PenaltyReturnTypeOnItsOwnLine: 100
+PenaltyBreakBeforeFirstCallParameter: 0
+PenaltyBreakOpenParenthesis: 200

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -75,7 +75,7 @@ jobs:
       run: |
         choco install --no-progress -y openssl
         echo "cmake -DPython3_ROOT_DIR=$env:pythonLocation"
-        cmake "-DPython3_ROOT_DIR=$env:pythonLocation" -DPython3_FIND_REGISTRY=LAST -DCMAKE_BUILD_TYPE=Release ..
+        cmake "-DPython3_ROOT_DIR=$env:pythonLocation" -DPython3_FIND_REGISTRY=LAST -DHTTPLIB_USE_ZLIB_IF_AVAILABLE=OFF -DCMAKE_BUILD_TYPE=Release ..
         cmake --build . --config Release
     - name: Deploy
       uses: actions/upload-artifact@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,12 +77,12 @@ jobs:
         echo "cmake -DPython3_ROOT_DIR=$env:pythonLocation"
         cmake "-DPython3_ROOT_DIR=$env:pythonLocation" -DPython3_FIND_REGISTRY=LAST -DCMAKE_BUILD_TYPE=Release ..
         cmake --build . --config Release
-    - name: Test
-      working-directory: build
-      run: |
-        ctest -C Release --verbose --no-test=fail
     - name: Deploy
       uses: actions/upload-artifact@v2
       with:
         name: zswag-py${{ matrix.python-version }}-${{ matrix.os }}
         path: build/bin/wheel/*.whl
+    - name: Test
+      working-directory: build
+      run: |
+        ctest -C Release --verbose --no-test=fail

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(FetchContent)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(ZSWAG_VERSION 1.4.0rc0)
+set(ZSWAG_VERSION 1.4.0rc1)
 
 option(ZSWAG_BUILD_WHEELS "Enable zswag whl-output to WHEEL_DEPLOY_DIRECTORY." ON)
 option(ZSWAG_KEYCHAIN_SUPPORT "Enable zswag keychain support." ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(FetchContent)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(ZSWAG_VERSION 1.3.0)
+set(ZSWAG_VERSION 1.4.0rc0)
 
 option(ZSWAG_BUILD_WHEELS "Enable zswag whl-output to WHEEL_DEPLOY_DIRECTORY." ON)
 option(ZSWAG_KEYCHAIN_SUPPORT "Enable zswag keychain support." ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(FetchContent)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(ZSWAG_VERSION 1.4.0rc1)
+set(ZSWAG_VERSION 1.4.0)
 
 option(ZSWAG_BUILD_WHEELS "Enable zswag whl-output to WHEEL_DEPLOY_DIRECTORY." ON)
 option(ZSWAG_KEYCHAIN_SUPPORT "Enable zswag keychain support." ON)

--- a/libs/httpcl/include/httpcl/http-settings.hpp
+++ b/libs/httpcl/include/httpcl/http-settings.hpp
@@ -24,6 +24,9 @@ using Query = std::multimap<std::string, std::string>;
  */
 struct Config
 {
+    Config() = default;
+    Config(std::string const& yamlConf);
+
     struct BasicAuthentication {
         std::string user;
         std::string password;
@@ -55,6 +58,12 @@ struct Config
      * May read keychain passwords which can block and require user interaction.
      */
     void apply(httplib::Client& cl) const;
+
+    /**
+     * Convert this configuration to a YAML string, which may
+     * be passed to the respective `Config(yamlConf)` constructor.
+     */
+    std::string toYaml() const;
 };
 
 /**

--- a/libs/httpcl/src/http-client.cpp
+++ b/libs/httpcl/src/http-client.cpp
@@ -31,6 +31,9 @@ auto makeClientAndApplyQuery(
     config.apply(*client);
 
     applyQuery(uri, config);
+    if (httpcl::log().should_log(spdlog::level::debug)) {
+        httpcl::log().debug("  ... full URI: {}", uri.build());
+    }
     return client;
 }
 
@@ -58,8 +61,9 @@ Result HttpLibHttpClient::get(const std::string& uriStr,
                               const Config& config)
 {
     auto uri = URIComponents::fromStrRfc3986(uriStr);
-    return makeResult(makeClientAndApplyQuery(uri, config, timeoutSecs_, sslCertStrict_)->Get(
-        uri.buildPath().c_str()));
+    return makeResult(
+        makeClientAndApplyQuery(uri, config, timeoutSecs_, sslCertStrict_)
+            ->Get(uri.buildPath().c_str()));
 }
 
 Result HttpLibHttpClient::post(const std::string& uriStr,
@@ -67,10 +71,12 @@ Result HttpLibHttpClient::post(const std::string& uriStr,
                                const Config& config)
 {
     auto uri = URIComponents::fromStrRfc3986(uriStr);
-    return makeResult(makeClientAndApplyQuery(uri, config, timeoutSecs_, sslCertStrict_)->Post(
-        uri.buildPath().c_str(),
-        body ? body->body : std::string(),
-        body ? body->contentType.c_str() : nullptr));
+    return makeResult(
+        makeClientAndApplyQuery(uri, config, timeoutSecs_, sslCertStrict_)
+            ->Post(
+                uri.buildPath().c_str(),
+                body ? body->body : std::string(),
+                body ? body->contentType.c_str() : nullptr));
 }
 
 Result HttpLibHttpClient::put(const std::string& uriStr,
@@ -78,10 +84,12 @@ Result HttpLibHttpClient::put(const std::string& uriStr,
                               const Config& config)
 {
     auto uri = URIComponents::fromStrRfc3986(uriStr);
-    return makeResult(makeClientAndApplyQuery(uri, config, timeoutSecs_, sslCertStrict_)->Put(
-        uri.buildPath().c_str(),
-        body ? body->body : std::string(),
-        body ? body->contentType.c_str() : nullptr));
+    return makeResult(
+        makeClientAndApplyQuery(uri, config, timeoutSecs_, sslCertStrict_)
+            ->Put(
+                uri.buildPath().c_str(),
+                body ? body->body : std::string(),
+                body ? body->contentType.c_str() : nullptr));
 }
 
 Result HttpLibHttpClient::del(const std::string& uriStr,
@@ -89,10 +97,12 @@ Result HttpLibHttpClient::del(const std::string& uriStr,
                               const Config& config)
 {
     auto uri = URIComponents::fromStrRfc3986(uriStr);
-    return makeResult(makeClientAndApplyQuery(uri, config, timeoutSecs_, sslCertStrict_)->Delete(
-        uri.buildPath().c_str(),
-        body ? body->body : std::string(),
-        body ? body->contentType.c_str() : nullptr));
+    return makeResult(
+        makeClientAndApplyQuery(uri, config, timeoutSecs_, sslCertStrict_)
+            ->Delete(
+                uri.buildPath().c_str(),
+                body ? body->body : std::string(),
+                body ? body->contentType.c_str() : nullptr));
 }
 
 Result HttpLibHttpClient::patch(const std::string& uriStr,
@@ -100,10 +110,12 @@ Result HttpLibHttpClient::patch(const std::string& uriStr,
                                 const Config& config)
 {
     auto uri = URIComponents::fromStrRfc3986(uriStr);
-    return makeResult(makeClientAndApplyQuery(uri, config, timeoutSecs_, sslCertStrict_)->Patch(
-        uri.buildPath().c_str(),
-        body ? body->body : std::string(),
-        body ? body->contentType.c_str() : nullptr));
+    return makeResult(
+        makeClientAndApplyQuery(uri, config, timeoutSecs_, sslCertStrict_)
+            ->Patch(
+                uri.buildPath().c_str(),
+                body ? body->body : std::string(),
+                body ? body->contentType.c_str() : nullptr));
 }
 
 Result MockHttpClient::get(const std::string& uri,

--- a/libs/httpcl/test/CMakeLists.txt
+++ b/libs/httpcl/test/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(httpcl-test
 target_link_libraries(httpcl-test
   PUBLIC
     httpcl
-    Catch2::Catch2)
+    Catch2::Catch2WithMain)
 
 if (ZSWAG_ENABLE_TESTING)
   add_test(NAME httpcl-test

--- a/libs/httpcl/test/src/main.cpp
+++ b/libs/httpcl/test/src/main.cpp
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>

--- a/libs/httpcl/test/src/uri.cpp
+++ b/libs/httpcl/test/src/uri.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "httpcl/uri.hpp"
 

--- a/libs/pyzswagcl/py-openapi-client.cpp
+++ b/libs/pyzswagcl/py-openapi-client.cpp
@@ -66,11 +66,14 @@ namespace
 void PyOpenApiClient::bind(py::module_& m) {
     auto serviceClient = py::class_<PyOpenApiClient>(m, "OAClient")
         .def(py::init<std::string, bool, httpcl::Config, std::optional<std::string>, std::optional<std::string>>(),
-             "url"_a, "is_local_file"_a = false, "config"_a = httpcl::Config(),
-             "api_key"_a = std::optional<std::string>(), "bearer"_a = std::optional<std::string>())
+            "url"_a, "is_local_file"_a = false, "config"_a = httpcl::Config(),
+            "api_key"_a = std::optional<std::string>(), "bearer"_a = std::optional<std::string>())
         // zserio >= 2.3.0
         .def("call_method", &PyOpenApiClient::callMethod,
-             "method_name"_a, "request"_a, "unused"_a);
+            "method_name"_a, "request"_a, "unused"_a)
+        .def("config", [](PyOpenApiClient const& self)->OpenAPIConfig const&{
+            return self.client_->config_;
+        }, py::return_value_policy::reference_internal);
 
     py::object serviceClientBase = py::module::import("zserio").attr("ServiceInterface");
     serviceClient.attr("__bases__") = py::make_tuple(serviceClientBase) + serviceClient.attr("__bases__");

--- a/libs/pyzswagcl/py-zswagcl.cpp
+++ b/libs/pyzswagcl/py-zswagcl.cpp
@@ -102,24 +102,25 @@ PYBIND11_MODULE(pyzswagcl, m)
                 host, port, user, pw, ""
             };
             return &self;
-        }, "host"_a, "port"_a, "user"_a, "pw"_a);
+        }, "host"_a, "port"_a, "user"_a, "pw"_a)
+        ;
 
     ///////////////////////////////////////////////////////////////////////////
     // OpenAPIConfig
     py::class_<OpenAPIConfig>(m, "OAConfig")
-            .def("__contains__", [](const OpenAPIConfig& self, std::string const& methodName) {
-                return self.methodPath.find(methodName) != self.methodPath.end();
-            }, py::is_operator(), "method_name"_a)
-
-            .def("__getitem__", [](const OpenAPIConfig& self, std::string const& methodName) {
-                auto it = self.methodPath.find(methodName);
-                if (it != self.methodPath.end())
-                    return it->second;
-                else
-                    throw std::runtime_error(
-                        "Could not find OpenAPI config for method name "s+methodName);
-            }, py::is_operator(), py::return_value_policy::reference_internal, "method_name"_a)
-            ;
+        .def("__contains__", [](const OpenAPIConfig& self, std::string const& methodName) {
+            return self.methodPath.find(methodName) != self.methodPath.end();
+        }, py::is_operator(), "method_name"_a)
+        .def("__getitem__", [](const OpenAPIConfig& self, std::string const& methodName) {
+            auto it = self.methodPath.find(methodName);
+            if (it != self.methodPath.end())
+                return it->second;
+            else
+                throw std::runtime_error(
+                    "Could not find OpenAPI config for method name "s+methodName);
+        }, py::is_operator(), py::return_value_policy::reference_internal, "method_name"_a)
+        .def_readonly("content", &OpenAPIConfig::content)
+        ;
 
     m.def("parse_openapi_config", [](std::string const& path){
         std::ifstream ifs;

--- a/libs/pyzswagcl/py-zswagcl.cpp
+++ b/libs/pyzswagcl/py-zswagcl.cpp
@@ -103,7 +103,14 @@ PYBIND11_MODULE(pyzswagcl, m)
             };
             return &self;
         }, "host"_a, "port"_a, "user"_a, "pw"_a)
-        ;
+        .def(py::pickle(
+            [](httpcl::Config const& self) {
+                return py::make_tuple(self.toYaml());
+            },
+            [](py::tuple const& t)
+            {
+                return Config(t[0].cast<std::string>());
+            }));
 
     ///////////////////////////////////////////////////////////////////////////
     // OpenAPIConfig

--- a/libs/zswag/test/calc/client.py
+++ b/libs/zswag/test/calc/client.py
@@ -1,6 +1,8 @@
 from enum import Enum
 import calculator.api as api
 from zswag import OAClient, HTTPConfig
+import json
+import pickle
 
 def run(host, port):
 
@@ -9,6 +11,10 @@ def run(host, port):
     failed = 0
     print(f"[py-test-client] Connecting to {server_url}", flush=True)
 
+    # Make sure that HTTP Config pickling works
+    config_pickled = pickle.dumps(HTTPConfig().header("x", "42"))
+    assert pickle.loads(config_pickled)
+
     def run_test(aspect, request, fn, expect, auth_args):
         nonlocal counter, failed
         counter += 1
@@ -16,6 +22,8 @@ def run(host, port):
             print(f"[py-test-client] Test#{counter}: {aspect}", flush=True)
             print(f"[py-test-client]   -> Instantiating client.", flush=True)
             oa_client = OAClient(f"http://{host}:{port}/openapi.json", **auth_args)
+            # Just make sure that OpenAPI JSON content is parsable
+            assert oa_client.config().content and json.loads(oa_client.config().content)
             client = api.Calculator.Client(oa_client)
             print(f"[py-test-client]   -> Running request.", flush=True)
             resp = fn(client, request)

--- a/libs/zswag/test/calc/client.py
+++ b/libs/zswag/test/calc/client.py
@@ -2,7 +2,6 @@ from enum import Enum
 import calculator.api as api
 from zswag import OAClient, HTTPConfig
 
-
 def run(host, port):
 
     server_url = f"http://{host}:{port}/openapi.json"
@@ -16,7 +15,8 @@ def run(host, port):
         try:
             print(f"[py-test-client] Test#{counter}: {aspect}", flush=True)
             print(f"[py-test-client]   -> Instantiating client.", flush=True)
-            client = api.Calculator.Client(OAClient(f"http://{host}:{port}/openapi.json", **auth_args))
+            oa_client = OAClient(f"http://{host}:{port}/openapi.json", **auth_args)
+            client = api.Calculator.Client(oa_client)
             print(f"[py-test-client]   -> Running request.", flush=True)
             resp = fn(client, request)
             if resp.value == expect:

--- a/libs/zswagcl/include/zswagcl/private/openapi-config.hpp
+++ b/libs/zswagcl/include/zswagcl/private/openapi-config.hpp
@@ -200,6 +200,11 @@ struct OpenAPIConfig
      * is an empty array of combinations, which means no auth required.
      */
     SecurityAlternatives defaultSecurityScheme;
+
+    /**
+     * Original OpenAPI YAML string from which this config was parsed.
+     */
+    std::string content;
 };
 
 ZSWAGCL_EXPORT extern const std::string ZSERIO_OBJECT_CONTENT_TYPE;

--- a/libs/zswagcl/src/base64.cpp
+++ b/libs/zswagcl/src/base64.cpp
@@ -105,7 +105,7 @@ static std::string decode(const std::string& alphabet,
                           bool (*is_base64_pred)(unsigned char),
                           std::string const& encoded_string)
 {
-    int in_len = encoded_string.size();
+    auto in_len = encoded_string.size();
     int i = 0;
     int j = 0;
     int in_ = 0;

--- a/libs/zswagcl/src/openapi-config.cpp
+++ b/libs/zswagcl/src/openapi-config.cpp
@@ -15,8 +15,8 @@ bool OpenAPIConfig::BasicAuth::checkOrApply(httpcl::Config& config, std::string&
         return true;
 
     std::regex basicAuthValueRe{
-            "^Basic .+$",
-            std::regex_constants::ECMAScript|std::regex_constants::icase
+        "^Basic .+$",
+        std::regex_constants::ECMAScript|std::regex_constants::icase
     };
 
     auto found = std::any_of(config.headers.begin(), config.headers.end(), [&](auto const& headerNameAndValue){

--- a/libs/zswagcl/src/openapi-parser.cpp
+++ b/libs/zswagcl/src/openapi-parser.cpp
@@ -391,11 +391,12 @@ static void parseServer(const YAMLScope& serverNode,
     }
 }
 
-OpenAPIConfig parseOpenAPIConfig(std::istream& s)
+OpenAPIConfig parseOpenAPIConfig(std::istream& ss)
 {
     OpenAPIConfig config;
+    config.content = std::string(std::istreambuf_iterator<char>(ss), {});
 
-    auto doc = YAML::Load(s);
+    auto doc = YAML::Load(config.content);
     YAMLScope docScope{"", doc};
     docScope["servers"].forEach([&](auto const& serverNode){
         try { parseServer(serverNode, config); }

--- a/libs/zswagcl/src/openapi-parser.cpp
+++ b/libs/zswagcl/src/openapi-parser.cpp
@@ -259,9 +259,10 @@ static void parseMethodBody(YAMLScope const& methodNode,
         if (auto contentNode = bodyNode["content"]) {
             for (auto contentTypeNode : contentNode.node_) {
                 auto contentType = contentTypeNode.first.as<std::string>();
-                if (contentType != ZSERIO_OBJECT_CONTENT_TYPE)
-                    throw contentNode.valueError(contentType, {ZSERIO_OBJECT_CONTENT_TYPE});
-                path.bodyRequestObject = true;
+                if (contentType == ZSERIO_OBJECT_CONTENT_TYPE)
+                    path.bodyRequestObject = true;
+                else
+                    httpcl::log().debug("Ignoring request body MIME type '{}'.", contentType);
             }
         }
     }

--- a/libs/zswagcl/test/CMakeLists.txt
+++ b/libs/zswagcl/test/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(zswagcl-test
   PUBLIC
     zswagcl-test-zs
     zswagcl
-    Catch2::Catch2)
+    Catch2::Catch2WithMain)
 
 target_compile_definitions(zswagcl-test
   PRIVATE

--- a/libs/zswagcl/test/src/base64.cpp
+++ b/libs/zswagcl/test/src/base64.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "../../src/base64.hpp"
 

--- a/libs/zswagcl/test/src/http-service-format.cpp
+++ b/libs/zswagcl/test/src/http-service-format.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "../src/http-service-format.hpp"
 

--- a/libs/zswagcl/test/src/main.cpp
+++ b/libs/zswagcl/test/src/main.cpp
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>

--- a/libs/zswagcl/test/src/oaclient.cpp
+++ b/libs/zswagcl/test/src/oaclient.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <fstream>
 

--- a/libs/zswagcl/test/src/openapi-parameter-helper.cpp
+++ b/libs/zswagcl/test/src/openapi-parameter-helper.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "zswagcl/private/openapi-parameter-helper.hpp"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ connexion
 requests
 zserio>=2.4.2
 pyyaml
-pyzswagcl>=1.4.0rc0
+pyzswagcl>=1.4.0
 openapi-spec-validator

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ connexion
 requests
 zserio>=2.4.2
 pyyaml
-pyzswagcl>=1.3.0
+pyzswagcl>=1.4.0rc0
 openapi-spec-validator


### PR DESCRIPTION
### Changes

- [x] Catch is now at v3.1 (simfil compatibility), zserio is at v2.8.0
- [x] HttpConfig supports pickle protocol, so it may be passed to Python subprocesses.
- [x] [#88] Provide access to OpenAPI JSON/YAML content
- [x] [#89] Ignore MIME types other than `application/x-zserio-object` and set `Accept-Encoding` header

Closes #88 
Closes #89 

Deployed as `1.4.0rc1`