### PR TITLE
Update zserio and httplib

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Configure
         run: |
           python3 -m venv venv && . ./venv/bin/activate
-          pip install -U setuptools wheel pip conan==2.0.8
+          pip install -U setuptools wheel pip conan==2.2.1
           mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
       - name: Build
         working-directory: build
@@ -65,7 +65,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
-    - run: python -m pip install setuptools wheel conan==2.0.8
+    - run: python -m pip install setuptools wheel conan==2.2.1
     - run: mkdir build
     - name: Build (macOS)
       if: matrix.os == 'macos-13'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 project(zswag)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(ZSWAG_VERSION 1.6.4)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ endif()
 if (NOT TARGET httplib)
   FetchContent_Declare(httplib
     GIT_REPOSITORY "https://github.com/yhirose/cpp-httplib.git"
-    GIT_TAG        "v0.15.0"
+    GIT_TAG        "v0.15.3"
     GIT_SHALLOW    ON)
   FetchContent_MakeAvailable(httplib)
   target_compile_definitions(httplib
@@ -118,7 +118,7 @@ if(ZSWAG_BUILD_WHEELS AND NOT TARGET pybind11)
 endif()
 
 if (NOT TARGET zserio-cmake-helper)
-  set(ZSERIO_VERSION "2.12.0")
+  set(ZSERIO_VERSION "2.13.0")
   FetchContent_Declare(zserio-cmake-helper
     GIT_REPOSITORY "https://github.com/Klebert-Engineering/zserio-cmake-helper.git"
     GIT_TAG        "main"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 project(zswag)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(ZSWAG_VERSION 1.6.4)
 

--- a/libs/httpcl/CMakeLists.txt
+++ b/libs/httpcl/CMakeLists.txt
@@ -40,4 +40,6 @@ if (ZSWAG_KEYCHAIN_SUPPORT)
   target_link_libraries(httpcl PUBLIC keychain::keychain)
 endif()
 
-add_subdirectory(test)
+if(ZSWAG_ENABLE_TESTING)
+  add_subdirectory(test)
+endif()

--- a/libs/zswagcl/CMakeLists.txt
+++ b/libs/zswagcl/CMakeLists.txt
@@ -41,5 +41,6 @@ target_include_directories(zswagcl
     include/zswagcl
   PUBLIC
     include)
-
-add_subdirectory(test)
+if(ZSWAG_ENABLE_TESTING)
+  add_subdirectory(test)
+endif()


### PR DESCRIPTION
Updates zserio to 2.13.0 and httplib to latest patch version.
Updates conan on the CI to run with latest Github runner
Excludes building test code when `ZSWAG_ENABLE_TESTING` is `OFF` (previously only running tests was omitted)