### PR TITLE
Fix httplib API calls for empty body #126

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: ubuntu-latest
-    container: ghcr.io/klebert-engineering/manylinux-cpp17-py${{ matrix.python-version }}-x86_64:2024.1
+    container: ghcr.io/klebert-engineering/manylinux-cpp17-py${{ matrix.python-version }}-x86_64:2024.2
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           echo "Node at $(which node): $(node -v); npm: $(npm -v)"
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Configure
         run: |
           python3 -m venv venv && . ./venv/bin/activate
@@ -37,7 +37,7 @@ jobs:
           . ../venv/bin/activate
           ctest -C Release --verbose --no-tests=error
       - name: Deploy
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: zswag-py${{ matrix.python-version }}-ubuntu-latest
           path: build/bin/wheel/*.whl
@@ -48,7 +48,7 @@ jobs:
         os: [macos-13, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Cache Conan packages
@@ -89,7 +89,7 @@ jobs:
         cmake "-DPython3_ROOT_DIR=$env:pythonLocation" -DPython3_FIND_REGISTRY=LAST -DCMAKE_BUILD_TYPE=Release -DZSWAG_ENABLE_TESTING=ON ..
         cmake --build . --config Release
     - name: Deploy
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: zswag-py${{ matrix.python-version }}-${{ matrix.os }}
         path: build/bin/wheel/*.whl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ project(zswag)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(ZSWAG_VERSION 1.7.0)
+set(ZSWAG_VERSION 1.7.1)
 
 option(ZSWAG_BUILD_WHEELS "Enable zswag whl-output to WHEEL_DEPLOY_DIRECTORY." ON)
 option(ZSWAG_KEYCHAIN_SUPPORT "Enable zswag keychain support." ON)

--- a/libs/httpcl/src/http-client.cpp
+++ b/libs/httpcl/src/http-client.cpp
@@ -64,7 +64,7 @@ Result HttpLibHttpClient::get(const std::string& uriStr,
     auto uri = URIComponents::fromStrRfc3986(uriStr);
     return makeResult(
         makeClientAndApplyQuery(uri, config, timeoutSecs_, sslCertStrict_)
-            ->Get(uri.buildPath().c_str()));
+            ->Get(uri.buildPath()));
 }
 
 Result HttpLibHttpClient::post(const std::string& uriStr,
@@ -75,9 +75,9 @@ Result HttpLibHttpClient::post(const std::string& uriStr,
     return makeResult(
         makeClientAndApplyQuery(uri, config, timeoutSecs_, sslCertStrict_)
             ->Post(
-                uri.buildPath().c_str(),
+                uri.buildPath(),
                 body ? body->body : std::string(),
-                body ? body->contentType.c_str() : nullptr));
+                body ? body->contentType : std::string()));
 }
 
 Result HttpLibHttpClient::put(const std::string& uriStr,
@@ -88,9 +88,9 @@ Result HttpLibHttpClient::put(const std::string& uriStr,
     return makeResult(
         makeClientAndApplyQuery(uri, config, timeoutSecs_, sslCertStrict_)
             ->Put(
-                uri.buildPath().c_str(),
+                uri.buildPath(),
                 body ? body->body : std::string(),
-                body ? body->contentType.c_str() : nullptr));
+                body ? body->contentType : std::string()));
 }
 
 Result HttpLibHttpClient::del(const std::string& uriStr,
@@ -101,9 +101,9 @@ Result HttpLibHttpClient::del(const std::string& uriStr,
     return makeResult(
         makeClientAndApplyQuery(uri, config, timeoutSecs_, sslCertStrict_)
             ->Delete(
-                uri.buildPath().c_str(),
+                uri.buildPath(),
                 body ? body->body : std::string(),
-                body ? body->contentType.c_str() : nullptr));
+                body ? body->contentType : std::string()));
 }
 
 Result HttpLibHttpClient::patch(const std::string& uriStr,
@@ -114,9 +114,9 @@ Result HttpLibHttpClient::patch(const std::string& uriStr,
     return makeResult(
         makeClientAndApplyQuery(uri, config, timeoutSecs_, sslCertStrict_)
             ->Patch(
-                uri.buildPath().c_str(),
+                uri.buildPath(),
                 body ? body->body : std::string(),
-                body ? body->contentType.c_str() : nullptr));
+                body ? body->contentType : std::string()));
 }
 
 Result MockHttpClient::get(const std::string& uri,


### PR DESCRIPTION
### Changes

Adapted the httplib interface calls to correctly pass `std::string()` instead of `nullptr`, plus simplifications. 

### Affected use-cases

Threw an exception when POST, PUT, etc. was called with empty request object.

