### PR TITLE
Make missing http-settings node in YAML file a no-op (#128)

### DIFF
--- a/libs/httpcl/src/http-settings.cpp
+++ b/libs/httpcl/src/http-settings.cpp
@@ -362,9 +362,13 @@ void Settings::load()
         uint32_t idx = 0;
 
         if (document.IsMap()) {
-            httpSettingsNode = document["http-settings"];
-        }
-        else {
+            auto settingsNode = document["http-settings"];
+            if (!settingsNode.IsDefined()) {
+                log().debug("No 'http-settings' section found in the YAML file.");
+                return;
+            }
+            httpSettingsNode = settingsNode;
+        } else {
             // Keep supporting the old format, where the root structure is a settings array.
             httpSettingsNode = document;
         }

--- a/libs/httpcl/src/http-settings.cpp
+++ b/libs/httpcl/src/http-settings.cpp
@@ -364,7 +364,7 @@ void Settings::load()
         if (document.IsMap()) {
             auto settingsNode = document["http-settings"];
             if (!settingsNode.IsDefined()) {
-                log().debug("No 'http-settings' section found in the YAML file.");
+                log().debug("No 'http-settings' section found in the YAML file '{}'.", cookieJar);
                 return;
             }
             httpSettingsNode = settingsNode;


### PR DESCRIPTION
Allows ignoring missing `http-settings` in settings YAML file.
