### PR TITLE
ci: Add support for Linux arm64 wheels.

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -37,8 +37,9 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-    runs-on: ubuntu-latest
-    container: ghcr.io/klebert-engineering/manylinux-cpp17-py${{ matrix.python-version }}-x86_64:2025.1
+        arch: ["x86_64", "aarch64"]
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    container: ghcr.io/klebert-engineering/manylinux-cpp17-py${{ matrix.python-version }}-${{ matrix.arch }}:2025.1
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
@@ -69,7 +70,7 @@ jobs:
       - name: Deploy
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux-py${{ matrix.python-version }}
+          name: wheels-linux-${{ matrix.arch }}-py${{ matrix.python-version }}
           path: build/bin/wheel/*.whl
   
   build:

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -134,7 +134,7 @@ if(ZSWAG_BUILD_WHEELS AND NOT TARGET wheel)
     FetchContent_Declare(
         python-cmake-wheel
         GIT_REPOSITORY https://github.com/Klebert-Engineering/python-cmake-wheel.git
-        GIT_TAG        "6e7b831"
+        GIT_TAG        "v1.0.0"
         GIT_SHALLOW    TRUE
     )
     FetchContent_MakeAvailable(python-cmake-wheel)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -134,7 +134,7 @@ if(ZSWAG_BUILD_WHEELS AND NOT TARGET wheel)
     FetchContent_Declare(
         python-cmake-wheel
         GIT_REPOSITORY https://github.com/Klebert-Engineering/python-cmake-wheel.git
-        GIT_TAG        "v0.9.0"
+        GIT_TAG        "6e7b831"
         GIT_SHALLOW    TRUE
     )
     FetchContent_MakeAvailable(python-cmake-wheel)

--- a/cmake/OpenSSL.cmake
+++ b/cmake/OpenSSL.cmake
@@ -57,6 +57,16 @@ else() # Linux and other Unix-like systems
     set(OPENSSL_LIB_SUFFIX ".a")
 endif()
 
+# Determine the library directory used by OpenSSL on Linux
+# x86_64 Linux uses lib64, but ARM64 uses lib
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+    set(OPENSSL_LIBDIR "lib")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(OPENSSL_LIBDIR "lib64")
+else()
+    set(OPENSSL_LIBDIR "lib")
+endif()
+
 # Build OpenSSL using ExternalProject
 ExternalProject_Add(openssl_build
     SOURCE_DIR ${OPENSSL_SOURCE_DIR}
@@ -69,8 +79,8 @@ ExternalProject_Add(openssl_build
         ${OPENSSL_INSTALL_DIR}/lib/${OPENSSL_LIB_PREFIX}crypto${OPENSSL_LIB_SUFFIX}
         $<$<STREQUAL:${CMAKE_SYSTEM_NAME},Windows>:${OPENSSL_INSTALL_DIR}/lib/ssl${OPENSSL_LIB_SUFFIX}>
         $<$<STREQUAL:${CMAKE_SYSTEM_NAME},Windows>:${OPENSSL_INSTALL_DIR}/lib/crypto${OPENSSL_LIB_SUFFIX}>
-        $<$<STREQUAL:${CMAKE_SYSTEM_NAME},Linux>:${OPENSSL_INSTALL_DIR}/lib64/${OPENSSL_LIB_PREFIX}ssl${OPENSSL_LIB_SUFFIX}>
-        $<$<STREQUAL:${CMAKE_SYSTEM_NAME},Linux>:${OPENSSL_INSTALL_DIR}/lib64/${OPENSSL_LIB_PREFIX}crypto${OPENSSL_LIB_SUFFIX}>
+        $<$<STREQUAL:${CMAKE_SYSTEM_NAME},Linux>:${OPENSSL_INSTALL_DIR}/${OPENSSL_LIBDIR}/${OPENSSL_LIB_PREFIX}ssl${OPENSSL_LIB_SUFFIX}>
+        $<$<STREQUAL:${CMAKE_SYSTEM_NAME},Linux>:${OPENSSL_INSTALL_DIR}/${OPENSSL_LIBDIR}/${OPENSSL_LIB_PREFIX}crypto${OPENSSL_LIB_SUFFIX}>
     LOG_CONFIGURE ON
     LOG_BUILD ON
     LOG_INSTALL ON
@@ -103,10 +113,10 @@ else()
     )
 endif()
 
-# Add a post-build command to handle lib64 vs lib directory issue on Linux systems only
+# Add a post-build command to handle lib64 vs lib directory issue on Linux x86_64 systems only
 # This ensures libraries are available in the expected lib/ directory
-# macOS installs directly to lib/, so this is only needed for Linux
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+# macOS and ARM64 Linux install directly to lib/, so this is only needed for x86_64 Linux
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
     add_custom_command(
         TARGET openssl_build POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E make_directory ${OPENSSL_INSTALL_DIR}/lib

--- a/cmake/OpenSSL.cmake
+++ b/cmake/OpenSSL.cmake
@@ -38,7 +38,10 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(OPENSSL_LIB_PREFIX "lib")
     set(OPENSSL_LIB_SUFFIX ".a")
 else() # Linux and other Unix-like systems
-    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    # Detect architecture for Linux
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+        set(OPENSSL_CONFIGURE_COMMAND ${OPENSSL_SOURCE_DIR}/Configure linux-aarch64 --prefix=${OPENSSL_INSTALL_DIR} --openssldir=${OPENSSL_INSTALL_DIR}/ssl no-shared no-tests)
+    elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
         set(OPENSSL_CONFIGURE_COMMAND ${OPENSSL_SOURCE_DIR}/Configure linux-x86_64 --prefix=${OPENSSL_INSTALL_DIR} --openssldir=${OPENSSL_INSTALL_DIR}/ssl no-shared no-tests)
     else()
         set(OPENSSL_CONFIGURE_COMMAND ${OPENSSL_SOURCE_DIR}/Configure linux-x86 --prefix=${OPENSSL_INSTALL_DIR} --openssldir=${OPENSSL_INSTALL_DIR}/ssl no-shared no-tests)


### PR DESCRIPTION
## Summary
This PR introduces Linux arm64 support using the new variants of the Klebert-Engineering's ManyLinux for arm64.

## Changes

### CI/CD Pipeline Updates
- Extended the GitHub Actions matrix build to include `aarch64` architecture alongside `x86_64`
- Updated runner selection logic to use `ubuntu-24.04-arm` for ARM64 builds and `ubuntu-latest` for x86_64
- Modified artifact naming convention to include architecture (`wheels-linux-${{ matrix.arch }}-py${{ matrix.python-version }}`)

### Build System Enhancements
- **OpenSSL Configuration**: 
  - Added ARM64 detection in CMake to properly configure OpenSSL builds with `linux-aarch64` target
  - Fixed library path handling: ARM64 Linux uses `lib/` directory while x86_64 uses `lib64/`
  - Introduced `OPENSSL_LIBDIR` variable to handle architecture-specific library paths
  - Conditionally apply lib64 symlink workaround only for x86_64 Linux builds

### Dependency Updates
- Updated `python-cmake-wheel` to commit `6e7b831` which includes fixes for static Python linking in manylinux containers

## Technical Details
- The changes ensure proper cross-compilation support for ARM64 Linux platforms
- OpenSSL now correctly builds with architecture-specific configurations
- Library path resolution is now architecture-aware, preventing build failures on ARM64

## Testing
- All existing tests pass on both x86_64 and aarch64 architectures
- Wheels are successfully built for Python 3.10, 3.11, 3.12, and 3.13 on both architectures

## TODOs:
- [x] Use official release of python-cmake-wheel (currently using specific commit)